### PR TITLE
[修正]  店家後台表單改為一個 

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -53,7 +53,7 @@ class Reservation < ApplicationRecord
   end
 
   def valid_total_guests
-    total_guests = adult_num + kid_num
+    total_guests = adults + kids
     vacant_table = restaurant.tables.where(status: 'vacant').where('seat_num >= ?', total_guests).first
 
     if vacant_table

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -42,6 +42,23 @@ class Reservation < ApplicationRecord
       .order(:date, :time)
   }
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name tel date restaurant_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ['restaurant']
+  end
+
+  def self.search(params)
+    result = all
+
+    result = result.where(date: params[:date_eq]) if params[:date_eq].present?
+
+    result = result.ransack('name_or_tel_cont' => params[:name_or_tel_cont]).result if params[:name_or_tel_cont].present?
+    result
+  end
+
   private
 
   def update_table_status
@@ -61,23 +78,6 @@ class Reservation < ApplicationRecord
     else
       errors.add(:base, '無法找到合適的空桌')
     end
-  end
-  
-  def self.ransackable_attributes(_auth_object = nil)
-    %w[name tel date restaurant_id]
-  end
-
-  def self.ransackable_associations(_auth_object = nil)
-    ['restaurant']
-  end
-
-  def self.search(params)
-    result = all
-
-    result = result.where(date: params[:date_eq]) if params[:date_eq].present?
-
-    result = result.ransack('name_or_tel_cont' => params[:name_or_tel_cont]).result if params[:name_or_tel_cont].present?
-    result
   end
 
   ransacker :name_or_tel_cont do

--- a/app/views/admin/reservations/edit.html.erb
+++ b/app/views/admin/reservations/edit.html.erb
@@ -1,54 +1,5 @@
-<%= turbo_frame_tag "reservation_edit_sm" do %>
-  <div class="w-[90vw] mx-auto my-3 border-2 rounded-xl collapse bg-base-100 lg:hidden">
-    <input type="checkbox" class="hidden collapse-toggle" id="collapse-form-toggle">
-    <label for="collapse-form-toggle" class="text-xl font-bold text-center cursor-pointer">
-      <h1 class="text-xl font-semibold">
-      <%= image_tag "logo.png", class:"inline w-14 md:w-30 xl:w-30 py-2" %>
-      編輯訂位
-      </h1>
-    </label>
-    <div class="p-1 collapse-content">
-      <%= form_with(model: @reservation, url: admin_restaurant_reservation_path(restaurant_id: @restaurant.id), data: { turbo: false }) do |f| %>
-
-        <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"/>
-
-        <div class="px-1 pb-1 ">
-          <%= f.text_field :name, class:"iding-input", placeholder: "姓名" %>
-
-          <%= f.text_field :tel, class: "iding-input", placeholder: "電話", type: "tel" %>
-
-          <div class="flex gap-2">
-            <%= f.date_field :date, class:"iding-input" %>
-
-            <%= f.time_field :time, class:"iding-input" %>
-          </div>
-
-          <div class="flex gap-2">
-            <%= f.number_field :adult_num, class: "iding-input", placeholder: "大人", min: 0 %>
-
-            <%= f.number_field :kid_num, class: "iding-input", placeholder: "小孩", min: 0 %>
-          </div>
-
-          <%= f.text_area :note, class:"iding-text-area", placeholder: "備註" %>
-          
-          <div class="flex gap-2">
-            <%= table_select_options(@restaurant) %>
-          </div>
-
-        </div>
-
-        <div class="flex flex-row-reverse py-6">
-          <div class="flex-initial m-auto">
-            <%= f.submit "修改訂位", class: "flex items-center px-5 py-2.5 font-medium tracking-wide text-white capitalize bg-black rounded-md hover:bg-gray-800 focus:outline-none focus:bg-gray-900 transition duration-300 transform active:scale-95 ease-in-out" %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
-<% end %>
-
 <div class="top-0 hidden w-4/5 lg:block lg:w-1/3">
-  <%= turbo_frame_tag "reservation_edit_lg" do %>
+  <%= turbo_frame_tag "reservation_edit" do %>
     <div class="mx-1 mt-5 bg-white border-4 border-b border-red-800 rounded-lg shadow">
       <div class="flex justify-center">
         <div>
@@ -72,9 +23,9 @@
             </div>
 
             <div class="flex gap-2">
-              <%= f.number_field :adult_num, class: "iding-input", placeholder: "大人", min: 0 %>
+              <%= f.number_field :adults, class: "iding-input", placeholder: "大人", min: 0 %>
 
-              <%= f.number_field :kid_num, class: "iding-input", placeholder: "小孩", min: 0 %>
+              <%= f.number_field :kids, class: "iding-input", placeholder: "小孩", min: 0 %>
             </div>
 
             <%= f.text_area :note, class:"iding-textarea", placeholder: "備註" %>

--- a/app/views/admin/reservations/search.html.erb
+++ b/app/views/admin/reservations/search.html.erb
@@ -27,8 +27,8 @@
         <td><%= ff.tel %></td>
         <td><%= ff.date.strftime("%m月%d日") %></td>
         <td><%= ff.time.strftime("%H:%M") %></td>
-        <td><%= ff.adult_num %></td>
-        <td><%= ff.kid_num %></td>
+        <td><%= ff.adults %></td>
+        <td><%= ff.kids %></td>
         <td><%= ff.note %></td>
       </tr>
     <% end %>  

--- a/app/views/admin/restaurants/show.html.erb
+++ b/app/views/admin/restaurants/show.html.erb
@@ -1,5 +1,5 @@
-<section class="h-screen lg:flex">
-  <div class="z-10 flex justify-between border-2 drawer bg-base-100 rounded-xl lg:drawer-open lg:border-0">
+<section data-controller="hamburger" class="h-screen lg:flex">
+  <div class="z-10 flex justify-between border-2 drawer bg-base-100 rounded-xl lg:drawer-open lg:border-0 ">
     <input id="my-drawer" type="checkbox" class="drawer-toggle" />
     <div class="lg:hidden">
       <%= image_tag "iding_logo.png", class: "w-36 m-auto py-2" %>
@@ -27,6 +27,7 @@
       </ul>
     </div>
   </div>
+
   <div>
     <div class="m-2 lg:mx-4">
       <div class="flex navbar bg-base-100 my-3 border-2 rounded-xl lg:w-[86vw]">
@@ -36,58 +37,20 @@
           <% end %>
         </div>
         <div class="m-auto lg:ml-auto">
-          <a class="text-xl normal-case btn btn-ghost">行事曆</a>
+          <a class="ml-6 text-xl normal-case btn btn-ghost lg:m-auto">行事曆</a>
         </div>
         <div class="lg:ml-auto">
           <a class="hidden normal-case btn btn-ghost lg:flex">時間軸</a>
           <a class="hidden normal-case btn btn-ghost lg:flex">列表</a>
           <a class="hidden normal-case btn btn-ghost lg:flex">桌位圖</a>
+          <button data-action="click->hamburger#switch" class="mx-2 lg:hidden"><i class="fa-solid fa-user-plus"></i></button>
         </div>
       </div>
     </div>
-
-    <%= turbo_frame_tag "reservation_edit_sm" do %>
-      <div class="w-[90vw] mx-auto my-3 border-2 rounded-xl collapse bg-base-100 lg:hidden">
-        <input type="checkbox" class="hidden collapse-toggle" id="collapse-form-toggle">
-        <label for="collapse-form-toggle" class="text-xl font-bold text-center cursor-pointer">
-          <h1 class="text-xl font-semibold">
-            <%= image_tag "logo.png", class: "inline w-14 md:w-30 xl:w-30 py-2" %>
-            新增訂位
-          </h1>
-        </label>
-        <div class="p-1 collapse-content">
-          <%= form_with(model: @reservation, url: admin_restaurant_reservations_path(@restaurant), method: :post, data: { turbo: false }) do |f| %>
-            <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"/>
-            <div class="px-1 pb-1">
-              <%= f.text_field :name, class: "iding-input", placeholder: "姓名" %>
-              <%= f.text_field :tel, class: "iding-input", placeholder: "電話", type: "tel" %>
-
-              <div class="flex gap-2">
-                <%= f.date_field :date, class: "iding-input" %>
-                <%= f.time_field :time, class: "iding-input" %>
-              </div>
-
-              <div>
-                <%= f.text_area :note, class: "iding-textarea", placeholder: "備註" %>
-              </div>
-
-              <div class="flex gap-3">
-                <%= table_select_options(@restaurant) %>
-              </div>
-      
-              <div class="flex flex-row-reverse py-6">
-                <div class="flex-initial m-auto">
-                  <%= f.submit "建立訂位", class: "flex items-center px-5 py-2.5 font-medium tracking-wide text-white capitalize bg-black rounded-md hover:bg-gray-800 focus:outline-none focus:bg-gray-900 transition duration-300 transform active:scale-95 ease-in-out" %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>  
-    <% end %>
-    <div class="lg:flex m-3 relative h-[calc(100%-96px)]">
-      <div class="top-0 hidden w-4/5 lg:block lg:w-1/3">
-        <turbo-frame id="reservation_edit_lg">
+    
+    <div  class="lg:flex m-3 relative h-[calc(100%-96px)]">
+      <div data-hamburger-target="nav" class="top-0 hidden w-4/5 m-auto lg:block lg:w-1/3">
+        <%= turbo_frame_tag "reservation_edit" do %>
           <div class="mx-1 mt-5 bg-white border-2 border-b rounded-lg shadow">
             <div class="flex justify-center">
               <div>
@@ -105,8 +68,8 @@
                   <%= f.time_field :time, class: "iding-input" %>
                 </div>
                 <div class="flex gap-2">
-                  <%= f.number_field :adult_num, class: "iding-input", placeholder: "大人", min: 0 %>
-                  <%= f.number_field :kid_num, class: "iding-input", placeholder: "小孩", min: 0 %>
+                  <%= f.number_field :adults, class: "iding-input", placeholder: "大人", min: 0 %>
+                  <%= f.number_field :kids, class: "iding-input", placeholder: "小孩", min: 0 %>
                 </div>
                 <%= f.text_area :note, class: "iding-textarea", placeholder: "備註" %>
                 <div class="flex gap-2">
@@ -120,8 +83,9 @@
               </div>
             <% end %>
           </div>
-        </turbo-frame>
+          <% end %>
       </div>
+    
       <div class="w-full lg:w-3/4 h-[calc(100%-100px)]">
         <div class="top-0 w-11/12 mx-auto mt-5 overflow-y-auto bg-white rounded-lg shadow border-3 lg:absolute lg:right-2 lg:w-4/6 lg:h-full">
           <% @reservations&.each do |reservation| %>
@@ -141,7 +105,7 @@
               <div class="flex items-center justify-around lg:mx-5 sm:justify-between">
                 <div class="flex">
                   <div class="my-auto">
-                    <%= link_to edit_admin_restaurant_reservation_path(restaurant_id: @restaurant.id, id: reservation.id), data: { turbo_frame: "reservation_edit_lg" } do %>
+                    <%= link_to edit_admin_restaurant_reservation_path(restaurant_id: @restaurant.id, id: reservation.id), data: { turbo_frame: "reservation_edit" } do %>
                       <i class="fa-solid fa-pen-to-square"></i>
                     <% end %>
                   </div>


### PR DESCRIPTION
將原本為了RWD的 店家後台訂位表單改成一個
RWD的部分使用stimulus開啟
先修改的原因是因為 這樣在編輯頁面的時候才能在同一個表單進行
不然現在都是兩個不同的表單送相同的地方

https://github.com/astrocamp/14th-iDing/assets/138083856/0e1f8730-6f08-4698-ad62-a3d09e690454

