### PR TITLE
修正, 增加餐廳描述框的寬度

### DIFF
--- a/app/views/admin/restaurants/index.html.erb
+++ b/app/views/admin/restaurants/index.html.erb
@@ -20,7 +20,7 @@
               <li class="my-2">名稱：<%= link_to restaurant.name, admin_restaurant_path(restaurant) %></li>
               <li class="my-2">電話：<%= restaurant.tel %></li>
               <li class="my-2">地址：<%= restaurant.address %></li>
-              <li class="my-2">描述：<%= restaurant.description %></li>
+              <li class="my-2 lg:w-96">描述：<%= restaurant.description %></li>
               <li class="my-2">統編：<%= restaurant.ubn %></li>
             </div>
             <div class="lg:flex lg:gap-5">


### PR DESCRIPTION
原本:
<img width="1311" alt="image" src="https://github.com/astrocamp/14th-iDing/assets/130822984/fce75f4b-6bc9-43c5-b9ab-7818031d3733">

新增後:
<img width="1292" alt="image" src="https://github.com/astrocamp/14th-iDing/assets/130822984/e099f27b-1abf-4b5d-b949-e42515a3df39">
