### PR TITLE
Issue/152 功能: 新增friendly_id , 餐聽路徑可以顯示為自訂的url, 訂單id 換成亂數

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'ransack'
 gem "jsbundling-rails"
 gem "aasm", "~> 5.5"
 gem 'twsms2', '~> 1.3'
+gem 'friendly_id', '~> 5.4.0'
 
 gem "pundit"
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -366,6 +368,7 @@ DEPENDENCIES
   devise (~> 4.9)
   dotenv-rails
   fog-aws (~> 3.19)
+  friendly_id (~> 5.4.0)
   jbuilder
   jsbundling-rails
   letter_opener

--- a/app/controllers/admin/holidays_controller.rb
+++ b/app/controllers/admin/holidays_controller.rb
@@ -28,7 +28,7 @@ module Admin
     end
 
     def set_restaurant
-      @restaurant = current_user.restaurants.find(params[:restaurant_id])
+      @restaurant = current_user.restaurants.friendly.find(params[:restaurant_id])
     end
 
     def set_holiday

--- a/app/controllers/admin/open_times_controller.rb
+++ b/app/controllers/admin/open_times_controller.rb
@@ -42,7 +42,7 @@ module Admin
     end
 
     def set_restaurant
-      @restaurant = current_user.restaurants.find(params[:restaurant_id])
+      @restaurant = current_user.restaurants.friendly.find(params[:restaurant_id])
     end
 
     def set_open_time

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -48,7 +48,7 @@ module Admin
     end
 
     def set_restaurant
-      @restaurant = current_user.restaurants.find(params[:restaurant_id])
+      @restaurant = current_user.restaurants.friendly.find(params[:restaurant_id])
     end
 
     def set_reservation

--- a/app/controllers/admin/restaurants_controller.rb
+++ b/app/controllers/admin/restaurants_controller.rb
@@ -60,7 +60,7 @@ module Admin
     end
 
     def set_restaurant
-      @restaurant = current_user.restaurants.find(params[:id])
+      @restaurant = current_user.restaurants.friendly.find(params[:id])
     end
   end
 end

--- a/app/controllers/admin/tables_controller.rb
+++ b/app/controllers/admin/tables_controller.rb
@@ -66,7 +66,7 @@ module Admin
     end
 
     def set_restaurant
-      @restaurant = current_user.restaurants.find(params[:restaurant_id])
+      @restaurant = current_user.restaurants.friendly.find(params[:restaurant_id])
     end
   end
 end

--- a/app/controllers/build_controller.rb
+++ b/app/controllers/build_controller.rb
@@ -45,7 +45,7 @@ class BuildController < ApplicationController
   end
 
   def success_page
-    @reservation = Reservation.find(params[:reservation_id])
+    @reservation = Reservation.friendly.find(params[:reservation_id])
   end
 
   private

--- a/app/controllers/build_controller.rb
+++ b/app/controllers/build_controller.rb
@@ -35,7 +35,7 @@ class BuildController < ApplicationController
       @reservation = @restaurant.reservations.create!(reservation_params)
 
       if step == steps.last
-        redirect_to success_page_path(reservation_id: @reservation.id), notice: '訂位成功！'
+        redirect_to success_page_path(@reservation.slug), notice: '訂位成功！'
         session.delete(:first_step_data)
         SendSmsJob.perform_later(@reservation)
       else

--- a/app/controllers/build_controller.rb
+++ b/app/controllers/build_controller.rb
@@ -68,7 +68,7 @@ class BuildController < ApplicationController
   end
 
   def set_restaurant
-    @restaurant = Restaurant.find(params[:restaurant_id])
+    @restaurant = Restaurant.friendly.find(params[:restaurant_id])
   end
 
   # TimeRange

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -32,7 +32,7 @@ class RestaurantsController < ApplicationController
   private
 
   def set_restaurant
-    @restaurant = Restaurant.find(params[:id])
+    @restaurant = Restaurant.friendly.find(params[:id])
   end
 
   # TimeRange

--- a/app/jobs/send_sms_job.rb
+++ b/app/jobs/send_sms_job.rb
@@ -4,10 +4,10 @@ class SendSmsJob < ApplicationJob
   queue_as :default
 
   def perform(reservation)
-    Rails.application.credentials[:twsms][:account]
-    Rails.application.credentials[:twsms][:password]
+    twsms_account = Rails.application.credentials[:twsms][:account]
+    twsms_password = Rails.application.credentials[:twsms][:password]
 
-    sms_client = Twsms2::Client.new(username: ENV.fetch('TWSMS', nil), password: ENV.fetch('TWSMS_PASSWORD', nil))
+    sms_client = Twsms2::Client.new(username: ENV["TWSMS"], password: ENV["TWSMS_PASSWORD"])
     sms_client.send_message to: reservation.tel.to_s,
                             content: "您已預約#{reservation.restaurant.name}。於#{reservation.date}的#{reservation.time.strftime('%R')}。您的訂位資料：http://iding.cc/success_page/#{reservation.slug}"
   end

--- a/app/jobs/send_sms_job.rb
+++ b/app/jobs/send_sms_job.rb
@@ -9,6 +9,6 @@ class SendSmsJob < ApplicationJob
 
     sms_client = Twsms2::Client.new(username: ENV.fetch('TWSMS', nil), password: ENV.fetch('TWSMS_PASSWORD', nil))
     sms_client.send_message to: reservation.tel.to_s,
-                            content: "您已預約#{reservation.restaurant.name}。於#{reservation.date}的#{reservation.time.strftime('%R')}。您的訂位資料：https://iding.cc/success_page/#{reservation.id}"
+                            content: "您已預約#{reservation.restaurant.name}。於#{reservation.date}的#{reservation.time.strftime('%R')}。您的訂位資料：http://iding.cc/success_page/#{reservation.slug}"
   end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -20,10 +20,10 @@
 #  gender        :integer
 #
 class Reservation < ApplicationRecord
+  extend FriendlyId
+  friendly_id :generate_random, use: :slugged
   acts_as_paranoid
   include AASM
-  # extend FriendlyId
-  # friendly_id :id, use: :slugged
 
   belongs_to :restaurant
   belongs_to :table, optional: true
@@ -123,5 +123,11 @@ class Reservation < ApplicationRecord
 
   def update_table_status_to_vacant
     table.vacant! if table.present? && table.may_vacant?
+  end
+
+  private
+
+  def generate_random
+    SecureRandom.hex(4)
   end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -22,6 +22,8 @@
 class Reservation < ApplicationRecord
   acts_as_paranoid
   include AASM
+  # extend FriendlyId
+  # friendly_id :id, use: :slugged
 
   belongs_to :restaurant
   belongs_to :table, optional: true

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -21,9 +21,10 @@
 #
 class Restaurant < ApplicationRecord
   acts_as_paranoid
-
   mount_uploader :image, ImageUploader
   mount_uploaders :menus, MenuUploader
+  extend FriendlyId
+  friendly_id :url, use: :slugged
 
   validates :name, presence: true
   validates :url, presence: true, uniqueness: true
@@ -36,4 +37,8 @@ class Restaurant < ApplicationRecord
   has_many :open_times, dependent: :destroy
   has_many :tables, dependent: :destroy
   has_many :holidays, dependent: :destroy
+
+  def should_generate_new_friendly_id?
+    url_changed? || super
+  end
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,106 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,106 +1,10 @@
 # FriendlyId Global Configuration
-#
-# Use this to set up shared configuration options for your entire application.
-# Any of the configuration options shown here can also be applied to single
-# models by passing arguments to the `friendly_id` class method or defining
-# methods in your model.
-#
-# To learn more, check out the guide:
-#
 # http://norman.github.io/friendly_id/file.Guide.html
 
 FriendlyId.defaults do |config|
   # ## Reserved Words
-  # Some words could conflict with Rails's routes when used as slugs, or are
-  # undesirable to allow as slugs. Edit this list as needed for your app.
   config.use :reserved
 
   config.reserved_words = %w(new edit index session login logout users admin
     stylesheets assets javascripts images)
-    
-  # This adds an option to treat reserved words as conflicts rather than exceptions.
-  # When there is no good candidate, a UUID will be appended, matching the existing
-  # conflict behavior.
-
-  # config.treat_reserved_as_conflict = true
-
-  #  ## Friendly Finders
-  #
-  # Uncomment this to use friendly finders in all models. By default, if
-  # you wish to find a record by its friendly id, you must do:
-  #
-  #    MyModel.friendly.find('foo')
-  #
-  # If you uncomment this, you can do:
-  #
-  #    MyModel.find('foo')
-  #
-  # This is significantly more convenient but may not be appropriate for
-  # all applications, so you must explicity opt-in to this behavior. You can
-  # always also configure it on a per-model basis if you prefer.
-  #
-  # Something else to consider is that using the :finders addon boosts
-  # performance because it will avoid Rails-internal code that makes runtime
-  # calls to `Module.extend`.
-  #
-  # config.use :finders
-  #
-  # ## Slugs
-  #
-  # Most applications will use the :slugged module everywhere. If you wish
-  # to do so, uncomment the following line.
-  #
-  # config.use :slugged
-  #
-  # By default, FriendlyId's :slugged addon expects the slug column to be named
-  # 'slug', but you can change it if you wish.
-  #
-  # config.slug_column = 'slug'
-  #
-  # By default, slug has no size limit, but you can change it if you wish.
-  #
-  # config.slug_limit = 255
-  #
-  # When FriendlyId can not generate a unique ID from your base method, it appends
-  # a UUID, separated by a single dash. You can configure the character used as the
-  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
-  # with two dashes.
-  #
-  # config.sequence_separator = '-'
-  #
-  # Note that you must use the :slugged addon **prior** to the line which
-  # configures the sequence separator, or else FriendlyId will raise an undefined
-  # method error.
-  #
-  #  ## Tips and Tricks
-  #
-  #  ### Controlling when slugs are generated
-  #
-  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
-  # nil, but if you're using a column as your base method can change this
-  # behavior by overriding the `should_generate_new_friendly_id?` method that
-  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
-  # more like 4.0.
-  # Note: Use(include) Slugged module in the config if using the anonymous module.
-  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
-  # is included after the anonymous module defined in the initializer, so it
-  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
-  #
-  # config.use :slugged
-  # config.use Module.new {
-  #   def should_generate_new_friendly_id?
-  #     slug.blank? || <your_column_name_here>_changed?
-  #   end
-  # }
-  #
-  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
-  # languages that don't use the Roman alphabet, that's not usually sufficient.
-  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
-  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
-  #
-  # config.use Module.new {
-  #   def normalize_friendly_id(text)
-  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
-  #   end
-  # }
 end

--- a/db/migrate/20230907064942_add_slug_to_restaurants.rb
+++ b/db/migrate/20230907064942_add_slug_to_restaurants.rb
@@ -1,0 +1,6 @@
+class AddSlugToRestaurants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :restaurants, :slug, :string
+    add_index :restaurants, :slug, unique: true
+  end
+end

--- a/db/migrate/20230907065021_create_friendly_id_slugs.rb
+++ b/db/migrate/20230907065021_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/migrate/20230907101550_add_slug_to_reservations.rb
+++ b/db/migrate/20230907101550_add_slug_to_reservations.rb
@@ -1,0 +1,6 @@
+class AddSlugToReservations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :reservations, :slug, :string
+    add_index :reservations, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_034843) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_065021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
 
   create_table "holidays", force: :cascade do |t|
     t.string "dayoff"
@@ -71,6 +82,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_034843) do
     t.datetime "deleted_at"
     t.json "menus"
     t.index ["deleted_at"], name: "index_restaurants_on_deleted_at"
+    t.string "slug"
+    t.index ["slug"], name: "index_restaurants_on_slug", unique: true
   end
 
   create_table "tables", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,11 +81,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_101550) do
     t.integer "reserve_interval", default: 15
     t.integer "mealtime", default: 60
     t.integer "bookday_advance", default: 14
-    t.string "slug"
     t.datetime "deleted_at"
     t.json "menus"
-    t.index ["deleted_at"], name: "index_restaurants_on_deleted_at"
     t.string "slug"
+    t.index ["deleted_at"], name: "index_restaurants_on_deleted_at"
     t.index ["slug"], name: "index_restaurants_on_slug", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_101550) do
     t.integer "reserve_interval", default: 15
     t.integer "mealtime", default: 60
     t.integer "bookday_advance", default: 14
+    t.string "slug"
     t.datetime "deleted_at"
     t.json "menus"
     t.index ["deleted_at"], name: "index_restaurants_on_deleted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_065021) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_101550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,8 +60,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_065021) do
     t.datetime "deleted_at"
     t.bigint "table_id"
     t.string "state", default: "reserved"
+    t.string "slug"
     t.index ["deleted_at"], name: "index_reservations_on_deleted_at"
     t.index ["restaurant_id"], name: "index_reservations_on_restaurant_id"
+    t.index ["slug"], name: "index_reservations_on_slug", unique: true
     t.index ["table_id"], name: "index_reservations_on_table_id"
   end
 


### PR DESCRIPTION
1. 餐廳的路徑可以顯示為url, 且更新的時候也能自動更新 餐廳的slug

https://github.com/astrocamp/14th-iDing/assets/130822984/9657330f-c58b-408e-94dd-2a638ca314e2

2. 訂單完成後可產生隨機亂數, 並且同步於簡訊跟頁面

https://github.com/astrocamp/14th-iDing/assets/130822984/074ba056-d431-47e4-a971-b6c12fcfab4d

![image](https://github.com/astrocamp/14th-iDing/assets/130822984/2499af84-8afd-41af-b67f-23ff03cfc294)

我在原本的分支是可以正常寄簡訊的, 但rebase上來後可能環境變數有更改的關係簡訊目前還沒辦法計
我先發pr, 明天會處理環境變數的部分