### PR TITLE
修正已選過的公休日仍然顯示在按鈕中

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,7 +7,7 @@
 }
 
 .unselect-btn {
-  @apply inline-block py-1 text-gray-800 bg-gray-100 border-gray-300 rounded cursor-pointer select-none lg:px-4 hover:bg-gray-200;
+  @apply py-1 text-gray-800 bg-gray-100 border-gray-300 rounded cursor-pointer select-none lg:px-4 hover:bg-gray-200;
 }
 
 .iding-input {

--- a/app/views/admin/open_times/index.html.erb
+++ b/app/views/admin/open_times/index.html.erb
@@ -61,14 +61,14 @@
         </div>
       </section>
 
-      <section class='max-w-xs mx-auto lg:mx-0 md:max-w-xl mt-5 bg-white border-2 shadow rounded-lg  min-w-[30%]' data-controller='holiday'>
+      <section class='max-w-xs mx-auto lg:mx-0 md:max-w-xl mt-5 bg-white border-2 shadow rounded-lg  min-w-[40%]' data-controller='holiday'>
         <h2 class='py-2 text-2xl font-bold text-center border-b'>公休日</h2>
         <div class='gap-2 p-6 text-left'>
           <div class='text-center'>
             <h3 class='mb-2 text-lg font-bold text-center lg:text-left'>新增公休日：</h3>
-            <div class='flex flex-wrap gap-2' id='holiday-selector'>
+            <div class='flex flex-wrap gap-1' id='holiday-selector'>
               <% @week.each do |date| %>
-                <button class='w-12 mx-1 md:w-auto unselect-btn' 
+                <button class='inline-block w-12 mx-1 md:w-auto unselect-btn' 
                       data-date='<%= date.strftime('%a') %>'
                       data-holiday-target='date'
                       data-action='click->holiday#getDate'>

--- a/app/views/build/date_time_person.html.erb
+++ b/app/views/build/date_time_person.html.erb
@@ -87,7 +87,7 @@
           <p class='w-full my-8 text-2xl font-bold text-center text-green'><%= t('reservationPage.Select Dining Date')%></p>
           <div class="grid grid-cols-3 mx-auto md:grid-cols-5 lg:grid-cols-7 xl:grid-cols-8 ">
             <% @daterange.each do |date| %>
-              <button class="max-w-sm mx-2 my-2 text-lg font-medium rounded-lg lg:mx-auto lg:my-2 lg:text-lg lg:w-32 unselect-btn"
+              <button class="inline-block max-w-sm mx-2 my-2 text-lg font-medium rounded-lg lg:mx-auto lg:my-2 lg:text-lg lg:w-32 unselect-btn"
                       data-ordertime-target='dateBtn'
                       data-action='click->ordertime#clickDate'
                       data-id='<%=@restaurant.id%>'

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -4,7 +4,7 @@
       <h4 class='reservation-font'>用餐日期</h4>
       <div class='grid grid-cols-5 gap-3 md:grid-cols-7'>
         <% @daterange.each do |date| %>
-          <button class='h-full py-1 unselect-btn'
+          <button class='inline-block h-full py-1 unselect-btn'
                   data-ordertime-target='dateBtn'
                   data-action='click->ordertime#clickDate'
                   data-id='<%=@restaurant.id%>'
@@ -22,7 +22,7 @@
       <h4 class='reservation-font'>用餐時間</h4>
       <div class='grid grid-cols-5 gap-3 md:grid-cols-7'>
         <% @timerange.each do |time_point| %>
-        <button class="unselect-btn" data-ordertime-target='timeBtn' data-action="click->ordertime#clickTime"
+        <button class="inline-block unselect-btn" data-ordertime-target='timeBtn' data-action="click->ordertime#clickTime"
                 value='<%= time_point %>'>
           <%= time_point %>
         </button>


### PR DESCRIPTION
<img width="1254" alt="image" src="https://github.com/astrocamp/14th-iDing/assets/130822984/f4d5f9d2-05b4-4554-bebf-27cc2782bd56">
有被選到的公休日要從上方移除

把inline-block 的屬性從 unselect-btn 拿去外面
不然holiday_controller 無法正常隱藏以被選取的公休日

正常要這樣子

https://github.com/astrocamp/14th-iDing/assets/130822984/d2a8edd2-79c9-4772-82e5-38b43ccc2662

