### PR TITLE
[修正] 自動排桌的Bug

### DIFF
--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -14,12 +14,11 @@ module Admin
 
     def create
       @reservation = @restaurant.reservations.new(reservation_params)
-
       if @reservation.save
         redirect_to admin_restaurant_path(@restaurant), notice: '訂位新增成功'
         SendSmsJob.perform_later(@reservation)
       else
-        redirect_to admin_restaurant_path(@restaurant), alert: '訂位失敗！請填寫必要欄位'
+        redirect_to admin_restaurant_path(@restaurant), alert: '請填寫必要欄位  或是<br> 該時段已無適合的空桌'
       end
     end
 

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -95,7 +95,7 @@ class Reservation < ApplicationRecord
     else
       self.table = nil
       errors.add(:base, '無法找到合適的空桌')
-      return false  
+      return false
     end
   end
   
@@ -103,7 +103,7 @@ class Reservation < ApplicationRecord
     @mealtime = restaurant.mealtime.minutes
     hour_before = reservation_time - @mealtime + 1
     hour_after = reservation_time + @mealtime - 1
-  
+
     suitable_table = restaurant.tables
       .where('seat_num >= ?', guests)
       .where.not(id: reserved_table_within_time_range(reservation_date, hour_before, hour_after))

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -88,7 +88,7 @@ class Reservation < ApplicationRecord
   def valid_total_guests
     total_guests = adults + kids
     suitable_table = find_suitable_table(total_guests, date, time)
-  
+
     if suitable_table
       self.table = suitable_table
       return true  
@@ -98,7 +98,7 @@ class Reservation < ApplicationRecord
       return false
     end
   end
-  
+
   def find_suitable_table(guests, reservation_date, reservation_time)
     @mealtime = restaurant.mealtime.minutes
     hour_before = reservation_time - @mealtime + 1


### PR DESCRIPTION
在原本的驗證方法，當餐廳只有一桌的情況
建立第一筆訂單時，會依照排桌邏輯自動安排第一桌，但如果此時在建立同時段的訂單的話，會直接建立成功且，桌號為nil
![排桌1](https://github.com/astrocamp/14th-iDing/assets/138083856/8415c7da-796e-4407-b411-43a5e4170fe1)
修正 判斷的方法
現在會若同時段新增後則會
![排桌2](https://github.com/astrocamp/14th-iDing/assets/138083856/06b210b2-8c17-4aa8-8e14-035ce81eabae)

消費者頁面則因為會自動依照桌子數篩選可以訂位的時間，所以這邊不用討論消費者的情況。