### PR TITLE
將日曆內日期連結字體加大

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -89,3 +89,11 @@
 .last {
   @apply hidden lg:inline-block;
 }
+
+.fc-daygrid-day-number {
+  @apply lg:text-2xl mr-auto;
+}
+
+.fc-event-title {
+  @apply hidden md:inline-block;
+}


### PR DESCRIPTION
<img width="1512" alt="截圖 2023-09-14 上午11 57 02" src="https://github.com/astrocamp/14th-iDing/assets/140604847/b142ded8-7938-4c17-9983-a4b69e2eadfe">
