### PR TITLE
最後修正

### DIFF
--- a/app/controllers/admin/restaurants_controller.rb
+++ b/app/controllers/admin/restaurants_controller.rb
@@ -39,7 +39,7 @@ module Admin
 
     def update
       if @restaurant.update(restaurant_params)
-        redirect_to admin_restaurant_path, notice: '餐廳資訊已更新'
+        redirect_to admin_restaurants_path, notice: '餐廳資訊已更新'
       else
         render :edit
       end

--- a/app/views/admin/holidays/_holiday.html.erb
+++ b/app/views/admin/holidays/_holiday.html.erb
@@ -1,8 +1,10 @@
-<span data-date='<%= holiday.dayoff %>' 
-      data-holiday-target='dayOff' class='flex items-center w-2/3 px-2 py-1 m-auto mt-2 border rounded md:w-full justify-evenly'
+<div data-date='<%= holiday.dayoff %>' 
+      data-holiday-target='dayOff' class='flex items-center w-2/3 px-2 py-1 m-auto mt-2 border rounded md:w-full justify-between'
 > 
-  <%= holiday.dayoff %>
+  <div class="m-auto">
+    <%= holiday.dayoff %>
+  </div>
   <%= link_to admin_holiday_path(holiday), data: {turbo_method: 'delete', turbo_confirm: '確認刪除？'},class: 'icon-btn' do %>
     <i class="fa-solid fa-xmark"></i>
   <% end %>
-</span>
+</div>

--- a/app/views/admin/open_times/_open_time.html.erb
+++ b/app/views/admin/open_times/_open_time.html.erb
@@ -3,7 +3,7 @@
     <%= open_time.start_time.strftime('%R') %> -
     <%= open_time.end_time.strftime('%R') %>
   </div>
-  <div class="flex justify-center ">
+  <div class="flex justify-center">
     <%= link_to admin_open_time_path(open_time), data: {turbo_method: 'delete', turbo_confirm: '確認刪除？'}, class: 'icon-btn' do %>
       <i class="fa-solid fa-xmark"></i>
     <% end %>

--- a/app/views/admin/open_times/index.html.erb
+++ b/app/views/admin/open_times/index.html.erb
@@ -63,9 +63,9 @@
 
       <section class='max-w-xs mx-auto mt-5 bg-white border-2 rounded-lg shadow lg:mx-0 md:max-w-xl lg:max-w-full' data-controller='holiday'>
         <h2 class='py-2 mb-10 text-2xl font-bold text-center border-b'>新增公休日</h2>
-        <div class='gap-2 p-6 text-left'>
+        <div class='gap-2 p-6'>
           <div class='w-full text-center lg:w-96'>
-            <div class='flex flex-wrap justify-between w-full gap-1' id='holiday-selector'>
+            <div class='flex flex-wrap w-full gap-6 lg:gap-9' id='holiday-selector'>
               <% @week.each do |date| %>
                 <button class='unselect-holiday-btn' 
                       data-date='<%= date.strftime('%a') %>'

--- a/app/views/admin/reservations/edit.html.erb
+++ b/app/views/admin/reservations/edit.html.erb
@@ -12,9 +12,9 @@
           <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"/>
 
           <div class="px-5 pb-5">
-            <%= form.text_field :name, class:"iding-input", placeholder: "姓名" %>
+            <%= form.text_field :name, class:"iding-input", placeholder: "姓名*", pattern: "^[a-zA-Z\u4e00-\u9fa5]+$", title: '姓名不得包含數字' %>
 
-            <%= form.text_field :tel, class: "iding-input", placeholder: "電話", type: "tel" %>
+            <%= form.text_field :tel, class: "iding-input", placeholder: "電話*", type: "tel", required: true, pattern: "[0-9]*", title: "請輸入電話號碼" %>
 
             <div class="flex gap-2">
               <%= form.date_field :date, data:{ controller: "flatpickr" }, class:"iding-input cursor-text" %>
@@ -23,9 +23,10 @@
             </div>
 
             <div class="flex gap-2">
-              <%= form.number_field :adults, class: "iding-input", placeholder: "大人", min: 0 %>
-
-              <%= form.number_field :kids, class: "iding-input", placeholder: "小孩", min: 0 %>
+              <%= form.label :adults ,"大人*",class: "w-36 flex mt-2 flex-col justify-center" %>
+              <%= form.number_field :adults, class: "iding-input", placeholder: "大人", min: 0, value: 1, required: true %>
+              <%= form.label :kids ,"小孩" ,class: "w-32 flex mt-2 flex-col justify-center"%>
+              <%= form.number_field :kids, class: "iding-input", placeholder: "小孩", min: 0, value: 0, required: true %>
             </div>
 
             <%= form.text_area :note, class:"iding-textarea", placeholder: "備註" %>

--- a/app/views/admin/restaurants/edit.html.erb
+++ b/app/views/admin/restaurants/edit.html.erb
@@ -27,7 +27,7 @@
                       <div class="m-1">
                         <%= f.label :tel, "餐廳電話*", class: 'leading-loose text-base' %>
                         <span class="block text-xs "><em>例 : XX-XXXX-XXXX</em></span>
-                        <%= f.phone_field :tel, pattern: "0[0-9]{1}-[0-9]{4}-[0-9]{4}", title: '請輸入您的餐廳電話', class: 'iding-customer-input', required: true %>
+                        <%= f.text_field :tel, pattern: "0[0-9]{1}-[0-9]{4}-[0-9]{4}", title: '請輸入您的餐廳電話', class: 'iding-customer-input', required: true %>
                       </div>
 
                       <div class="m-1">

--- a/app/views/admin/restaurants/new.html.erb
+++ b/app/views/admin/restaurants/new.html.erb
@@ -29,7 +29,7 @@
                     <div class="mx-1 my-3">
                       <%= f.label :tel, "餐廳電話*", class: "leading-loose text-base" %>
                       <span class="block text-xs "><em>例 : XX-XXXX-XXXX</em></span>
-                      <%= f.phone_field :tel, pattern: "0[0-9]{1}-[0-9]{4}-[0-9]{4}", title: '請輸入您的餐廳電話', class: "iding-customer-input", required: true %>
+                      <%= f.text_field :tel, pattern: "0[0-9]{1}-[0-9]{4}-[0-9]{4}", title: '請輸入您的餐廳電話', class: "iding-customer-input", required: true %>
                     </div>
                   </div>
 

--- a/app/views/admin/restaurants/show.html.erb
+++ b/app/views/admin/restaurants/show.html.erb
@@ -18,10 +18,10 @@
               <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"/>
               <div class="px-5 pb-5">
                 <%= form.text_field :name, class: "iding-input", placeholder: "姓名*", required: true, pattern: "^[a-zA-Z\u4e00-\u9fa5]+$", title: '姓名不得包含數字' %>
-                <%= form.phone_field :tel, class:"iding-input", placeholder: "電話*", type: "tel", required: true %>
+                <%= form.text_field :tel, class: "iding-input", placeholder: "電話*", type: "tel", required: true, pattern: "[0-9]*", title: "請輸入電話號碼" %>
                 <div class="flex gap-2">
-                  <%= form.date_field :date, placeholder: "日期", data: { controller: "flatpickr" }, class: "iding-input cursor-text",required: true %>
-                  <%= form.time_field :time, placeholder: "時間", data: { controller: "flatpickr" }, class: "iding-input cursor-text", required: true %>
+                  <%= form.date_field :date, placeholder: "日期*", data: { controller: "flatpickr" }, class: "iding-input cursor-text",required: true %>
+                  <%= form.time_field :time, placeholder: "時間*", data: { controller: "flatpickr" }, class: "iding-input cursor-text", required: true %>
                 </div>
                 <div class="flex gap-2">
                   <%= form.label :adults ,"大人*",class: "w-36 flex mt-2 flex-col justify-center" %>

--- a/app/views/build/customer_info.html.erb
+++ b/app/views/build/customer_info.html.erb
@@ -56,7 +56,7 @@
         </div>
         <div class="mt-4">
           <%= f.label :tel, t('customerInfo.Phone *'),class:"block text-sm text-gray-00 " %>
-          <%= f.phone_field :tel, pattern: '[09]{2}[0-9]{8}', title: '請輸入您的手機號碼', data: {customerinfo_target: "telInput", action: 'change->customerinfo#checkData'},class:"text-black placeholder-gray-600 w-full px-4 py-2.5 mt-2 text-base transition duration-500 ease-in-out transform border-transparent rounded-lg bg-gray-200 focus:bg-white focus:outline-none focus:ring-gray-400 focus:ring-2 ring-offset-2  focus:border-gray-500" %>
+          <%= f.text_field :tel, pattern: '[09]{2}[0-9]{8}', title: '請輸入您的手機號碼', data: {customerinfo_target: "telInput", action: 'change->customerinfo#checkData'},class:"text-black placeholder-gray-600 w-full px-4 py-2.5 mt-2 text-base transition duration-500 ease-in-out transform border-transparent rounded-lg bg-gray-200 focus:bg-white focus:outline-none focus:ring-gray-400 focus:ring-2 ring-offset-2  focus:border-gray-500" %>
         </div>
         <div class="mt-4">
           <%= f.label :email, 'Email',class:"block text-sm text-gray-00" %>


### PR DESCRIPTION
- 修正 餐廳修改網址後原轉址報404錯誤 改為 轉回帳號所開的餐廳列表

- 修正 新增公休日 星期的排版 與 星期刪除鍵的位置
<img width="1512" alt="截圖 2023-09-15 下午4 54 23" src="https://github.com/astrocamp/14th-iDing/assets/140604847/aaa94995-0ea0-4bcd-9722-867673345024">

- 日期時間 placeholder 加上*
<img width="1512" alt="截圖 2023-09-15 下午4 57 02" src="https://github.com/astrocamp/14th-iDing/assets/140604847/56017202-f46f-4408-9a2e-a397f471e867">

- phone_field 無作用 改成 text_field
